### PR TITLE
unmultiplied health and damage popup displays by 10

### DIFF
--- a/modules/DamagePopup.lua
+++ b/modules/DamagePopup.lua
@@ -146,7 +146,7 @@ if string.lower(RequiredScript) == "lib/units/enemies/cop/copdamage" then
 	end
 
 	function CopDamage:build_popup_text(damage, headshot, is_new)
-		self._dmg_value = (not is_new and self._dmg_value or 0) + (damage * 10)
+		self._dmg_value = (not is_new and self._dmg_value or 0) + (damage)
 		return math.floor(self._dmg_value) .. ((CopDamage.DMG_POPUP_SETTING == 3 and headshot) and "!" or "")
 	end
 

--- a/modules/DamagePopup.lua
+++ b/modules/DamagePopup.lua
@@ -146,7 +146,7 @@ if string.lower(RequiredScript) == "lib/units/enemies/cop/copdamage" then
 	end
 
 	function CopDamage:build_popup_text(damage, headshot, is_new)
-		self._dmg_value = (not is_new and self._dmg_value or 0) + (damage)
+		self._dmg_value = (not is_new and self._dmg_value or 0) + (damage * 1)
 		return math.floor(self._dmg_value) .. ((CopDamage.DMG_POPUP_SETTING == 3 and headshot) and "!" or "")
 	end
 

--- a/modules/FloatingHealthBars.lua
+++ b/modules/FloatingHealthBars.lua
@@ -303,8 +303,8 @@ if string.lower(RequiredScript) == "lib/setups/gamesetup" then
 		pDist = dx * dx + dy * dy
 		self.pnl:set_visible(dot > 0)
 		if dot > 0 then
-			local cHealth = unit:character_damage() and unit:character_damage()._health and unit:character_damage()._health * 10 or 0
-			local fHealth = cHealth > 0 and unit:character_damage() and (unit:character_damage()._HEALTH_INIT and unit:character_damage()._HEALTH_INIT * 10 or unit:character_damage()._health_max and unit:character_damage()._health_max * 10) or 1
+			local cHealth = unit:character_damage() and unit:character_damage()._health and unit:character_damage()._health * 1 or 0
+			local fHealth = cHealth > 0 and unit:character_damage() and (unit:character_damage()._HEALTH_INIT and unit:character_damage()._HEALTH_INIT * 1 or unit:character_damage()._health_max and unit:character_damage()._health_max * 1) or 1
 			local prog = cHealth / fHealth
 			local isEnemy = managers.enemy:is_enemy(unit)
 			local show = isEnemy or WolfgangHUD:getSetting({"HUD", "FHB", "SHOW_FRIENDLY"}, false)


### PR DESCRIPTION
unmultiplies the hp and damage popups by 10 because RAID does not multiply health by 10 at all, which i immediately caught wind of when i shot an enemy with supposedly 750 health with a 54 damage weapon. the damage popup reported that i did 540 damage, which is clearly incorrect. 